### PR TITLE
Fixes #19 with a possible API candidate

### DIFF
--- a/ClickThroughBlocker/CBTGlobalMonitor.cs
+++ b/ClickThroughBlocker/CBTGlobalMonitor.cs
@@ -35,7 +35,7 @@ namespace ClickThroughFix
                 {
                     if (w.Value.win.lastUpdated < globalTimeTics - 4)
                     {
-                        FocusLock.FreeLock(w.Key, 1);
+                        FocusLock.FreeLock(w.Key, w.Value.win, 1);
                         w.Value.win.OnDestroy();
                         break;
                     }

--- a/ClickThroughBlocker/FocusLock.cs
+++ b/ClickThroughBlocker/FocusLock.cs
@@ -33,8 +33,10 @@ namespace ClickThroughFix
             {
                 focusLockDict.Add(lockName, new FocusLock(lockName, win));
             }
+
+            ClickThruBlocker.InvokeFocusCallbacks(win.id, true);
         }
-        internal static void FreeLock(string lockName, int i)
+        internal static void FreeLock(string lockName, ClickThruBlocker.CTBWin win, int i)
         {
             focusLockDict.Remove(lockName);
             // flight
@@ -42,6 +44,8 @@ namespace ClickThroughFix
                 InputLockManager.RemoveControlLock(lockName);
             else
                 EditorLogic.fetch.Unlock(lockName);
+
+            ClickThruBlocker.InvokeFocusCallbacks(win.id, false);
         }
     }
 


### PR DESCRIPTION
**There are two halves to this:**

Firstly, this seems to addresses issue #19 and the API looks like
it's working and pretty easy to use if you like it.  (Maybe you have
a better idea how to do it, and that's fine if you do.)  Included
in the PR is an example of how to call the API, in a #DEBUG section
with the class ``CTBWindowsTest``.

Secondly, that example in the PR also serves an ulterior motive.
I've been encountering something I think is a bug in ClickThroughBlocker, that I wanted to have a good solid but simple example to demonstrate it - and the example included in this PR shows what I mean without all the messy extra kOS stuff getting in the way obfuscating the issue.

If you read the long comment in the PR just above ``CTBWindowsTest``, it explains it.