### PR TITLE
Fix cfg syntax error

### DIFF
--- a/GameData/000_ClickThroughBlocker/changelog.cfg
+++ b/GameData/000_ClickThroughBlocker/changelog.cfg
@@ -12,7 +12,7 @@ KERBALCHANGELOG
 		version = 0.1.10.17
 		CHANGE
 		{
- 			change - Added AssemblyFileVersion, needed for new KSP 1.12 dll verification
+ 			change = Added AssemblyFileVersion, needed for new KSP 1.12 dll verification
 			change = Added InstallChecker to ensure installation into correct directory
 			type = update
 		}


### PR DESCRIPTION
Hi @linuxgurugamer,

I've been working on some cfg parser code for KSP-CKAN/CKAN#3525, and I tested it on this mod and found a minor syntax error (`-` where there should be a `=`).

This pull request fixes it.

Cheers!