### PR TITLE
Universal click-through block for IMGUI windows on PAW / uGUI

### DIFF
--- a/ClickThroughBlocker/ClearInputLocks.cs
+++ b/ClickThroughBlocker/ClearInputLocks.cs
@@ -19,6 +19,7 @@ namespace ClickThroughFix
         static internal ToolbarControl toolbarControl = null;
         static internal ToolbarControl clickThroughToggleControl = null;
         static internal bool focusFollowsclick = false;
+        static internal bool universalClickBlocking = false;
 
         const string FFC_38 = "000_ClickThroughBlocker/PluginData/FFC-38";
         const string FFM_38 = "000_ClickThroughBlocker/PluginData/FFM-38";

--- a/ClickThroughBlocker/ClickThroughBlocker.cs
+++ b/ClickThroughBlocker/ClickThroughBlocker.cs
@@ -222,7 +222,7 @@ namespace ClickThroughFix
             }
         }
 #endif
-        // This is outside the UpdateList method for runtime optimization 
+        // This is outside the UpdateList method for runtime optimization
         static CTBWin win = null;
         private static Rect UpdateList(int id, Rect rect, string text)
         {
@@ -246,6 +246,20 @@ namespace ClickThroughFix
 
 #endif
             return rect;
+        }
+
+        // Returns true when the cursor is over any IMGUI window drawn this frame.
+        // The set of rects is populated from Harmony postfixes on every
+        // GUILayout.Window / GUI.Window overload (see HarmonyPatches.cs), so this
+        // covers both CTB-wrapped windows and plain mod windows that haven't adopted
+        // CTB (MechJeb, etc.). Used by the click-blocking Harmony patches.
+        public static bool MouseOverAnyWindow()
+        {
+#if DUMMY
+            return false;
+#else
+            return IMGUIWindowTracker.MouseOverAnyWindow();
+#endif
         }
 
         // This is outside all the GuiLayoutWindow methods for runtime optimization

--- a/ClickThroughBlocker/ClickThroughBlocker.csproj
+++ b/ClickThroughBlocker/ClickThroughBlocker.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ClickThroughBlocker.cs" />
     <Compile Include="FocusLock.cs" />
     <Compile Include="GlobalFlagStorage.cs" />
+    <Compile Include="HarmonyPatches.cs" />
     <Compile Include="InstallChecker.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="OneTimePopup.cs" />
@@ -84,6 +85,10 @@
     <Reference Include="System" />
     <Reference Include="ToolbarControl">
       <HintPath>$(KSPDIR)\GameData\001_ToolbarControl\Plugins\ToolbarControl.dll</HintPath>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(KSPDIR)\GameData\000_Harmony\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ClickThroughBlocker/HarmonyPatches.cs
+++ b/ClickThroughBlocker/HarmonyPatches.cs
@@ -1,0 +1,188 @@
+#if !DUMMY
+using HarmonyLib;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+// CTB's existing InputLockManager / EditorLogic-based locks block IMGUI-on-IMGUI and
+// IMGUI-on-KSP-input click-through, but they don't reliably block clicks from reaching
+// Unity's uGUI EventSystem or the stock Part Action Window. These Harmony patches
+// fill that gap by tracking every IMGUI window drawn this frame and short-circuiting
+// the click-dispatch paths when the cursor is over any of them. Windows that haven't
+// adopted CTB (MechJeb etc., which use plain GUILayout.Window) are protected too.
+
+namespace ClickThroughFix
+{
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    internal class CTBHarmonyLoader : MonoBehaviour
+    {
+        private const string HarmonyId = "ClickThroughFix.CTB";
+        private const string UniversalLockId = "CTB_universal_IMGUI";
+        private static bool _patched;
+        private bool _flightLocked;
+        private bool _editorLocked;
+
+        internal void Awake()
+        {
+            DontDestroyOnLoad(this);
+            if (_patched) return;
+            _patched = true;
+            try
+            {
+                new Harmony(HarmonyId).PatchAll(typeof(CTBHarmonyLoader).Assembly);
+            }
+            catch (System.Exception e)
+            {
+                Log.Error("CTB Harmony patching failed: " + e);
+            }
+        }
+
+        // KSP's editor part-pick (single + double click to move) and various flight
+        // controls poll Input.GetMouseButton directly and honor InputLockManager /
+        // EditorLogic locks. uGUI raycaster suppression doesn't reach those paths.
+        // Set a universal lock whenever the cursor is over any tracked IMGUI window
+        // so a click meant for the mod window doesn't also grab a part in the editor.
+        internal void Update()
+        {
+            // Sync the static enable flag from the per-save CTB settings each frame so
+            // toggling the option in the stock settings UI takes effect immediately.
+            if (HighLogic.CurrentGame != null)
+                ClearInputLocks.universalClickBlocking =
+                    HighLogic.CurrentGame.Parameters.CustomParams<CTB>().universalClickBlocking;
+
+            bool over = ClearInputLocks.universalClickBlocking && IMGUIWindowTracker.MouseOverAnyWindow();
+            bool wantEditor = over && HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null;
+            bool wantFlight = over && (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneHasPlanetarium);
+
+            if (wantEditor != _editorLocked)
+            {
+                if (wantEditor) EditorLogic.fetch.Lock(true, true, true, UniversalLockId);
+                else if (EditorLogic.fetch != null) EditorLogic.fetch.Unlock(UniversalLockId);
+                _editorLocked = wantEditor;
+            }
+            if (wantFlight != _flightLocked)
+            {
+                if (wantFlight) InputLockManager.SetControlLock(ControlTypes.ALLBUTCAMERAS, UniversalLockId);
+                else InputLockManager.RemoveControlLock(UniversalLockId);
+                _flightLocked = wantFlight;
+            }
+        }
+    }
+
+    // Records the screen-space rect of every IMGUI window drawn this frame.
+    // Accumulates within a Unity frame across all OnGUI iterations (Layout, Repaint,
+    // MouseDown, …) — Unity dispatches MouseDown only to the focused window's body,
+    // so per-iter clearing would lose the rest of the visible windows. Swap to
+    // _lastRects at each new Unity frame so EventSystem.RaycastAll (running in
+    // Update before this frame's OnGUI) sees the previous frame's full set.
+    internal static class IMGUIWindowTracker
+    {
+        private static List<Rect> _curRects = new List<Rect>();
+        private static List<Rect> _lastRects = new List<Rect>();
+        private static int _frame = -1;
+
+        // Transform the returned window rect through the current GUI.matrix so we store
+        // actual screen-pixel bounds. KSP applies a UI_SCALE matrix that some mods (KAC)
+        // live inside; others (MechJeb) override GUI.matrix and draw in screen coords
+        // directly. By transforming through the matrix in effect at return time, the
+        // stored rect is always in screen-space and Contains(Input.mousePosition) works
+        // for both kinds of mods.
+        public static void RecordScreenSpace(Rect r)
+        {
+            if (!ClearInputLocks.universalClickBlocking) return;
+            var m = GUI.matrix;
+            Vector3 tl = m.MultiplyPoint3x4(new Vector3(r.xMin, r.yMin, 0f));
+            Vector3 br = m.MultiplyPoint3x4(new Vector3(r.xMax, r.yMax, 0f));
+            EnsureFrame();
+            _curRects.Add(Rect.MinMaxRect(
+                Mathf.Min(tl.x, br.x),
+                Mathf.Min(tl.y, br.y),
+                Mathf.Max(tl.x, br.x),
+                Mathf.Max(tl.y, br.y)));
+        }
+
+        public static bool MouseOverAnyWindow()
+        {
+            if (!ClearInputLocks.universalClickBlocking) return false;
+            EnsureFrame();
+            Vector2 mp = Input.mousePosition;
+            mp.y = Screen.height - mp.y;
+            for (int i = 0; i < _curRects.Count; i++)
+                if (_curRects[i].Contains(mp)) return true;
+            for (int i = 0; i < _lastRects.Count; i++)
+                if (_lastRects[i].Contains(mp)) return true;
+            return false;
+        }
+
+        private static void EnsureFrame()
+        {
+            int frame = Time.frameCount;
+            if (frame == _frame) return;
+            var tmp = _lastRects;
+            _lastRects = _curRects;
+            _curRects = tmp;
+            _curRects.Clear();
+            _frame = frame;
+        }
+    }
+
+    // Hook every GUI.Window / GUILayout.Window overload so we catch every IMGUI
+    // window regardless of which entry point the mod used. Double-records for
+    // GUILayout-routed windows (which internally call GUI.Window) are harmless —
+    // MouseOverAnyWindow only checks Contains.
+    [HarmonyPatch]
+    internal class CTB_TrackIMGUIWindows
+    {
+        [HarmonyTargetMethods]
+        internal static IEnumerable<MethodBase> Targets()
+        {
+            foreach (var t in new[] { typeof(GUI), typeof(GUILayout) })
+                foreach (var m in t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                    if (m.Name == "Window") yield return m;
+        }
+
+        [HarmonyPostfix]
+        internal static void Postfix(Rect __result) => IMGUIWindowTracker.RecordScreenSpace(__result);
+    }
+
+    // Suppress a uGUI raycaster's hits when the cursor is over a tracked IMGUI mod
+    // window. Stock KSP uGUI canvases overlap each other constantly (MainCanvas,
+    // AppCanvas, Editor are all near-full-screen), so any further "is another canvas
+    // covering us" heuristic just blocks legitimate stock UI clicks.
+    [HarmonyPatch(typeof(GraphicRaycaster))]
+    internal class CTB_GraphicRaycaster_Raycast
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("Raycast")]
+        [HarmonyPatch(new[] { typeof(PointerEventData), typeof(List<RaycastResult>) })]
+        internal static bool Prefix()
+        {
+            return !ClickThruBlocker.MouseOverAnyWindow();
+        }
+    }
+
+    // Right-click on a part runs UIPartActionController.MouseClickCoroutine which opens
+    // or closes the PAW. Bail when the cursor is over a registered CTB window so a
+    // right-click meant for the mod window doesn't also pop up the PAW behind it.
+    [HarmonyPatch(typeof(UIPartActionController))]
+    internal class CTB_UIPartActionController_MouseClickCoroutine
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("MouseClickCoroutine")]
+        internal static bool Prefix(ref IEnumerator __result)
+        {
+            if (ClickThruBlocker.MouseOverAnyWindow())
+            {
+                __result = NoOp();
+                return false;
+            }
+            return true;
+        }
+
+        private static IEnumerator NoOp() { yield break; }
+    }
+}
+#endif

--- a/ClickThroughBlocker/OneTimePopup.cs
+++ b/ClickThroughBlocker/OneTimePopup.cs
@@ -13,7 +13,7 @@ namespace ClickThroughFix
     {
         internal static OneTimePopup Instance = null;
         const int WIDTH = 600;
-        const int HEIGHT = 350;
+        const int HEIGHT = 400;
         Rect popupRect = new Rect(300, 50, WIDTH, HEIGHT);
         bool visible = false;
         static string popUpShownCfgPath { get { 
@@ -41,6 +41,7 @@ namespace ClickThroughFix
         {
 
             visible = true;
+            universalClickBlocking = HighLogic.CurrentGame.Parameters.CustomParams<CTB>().universalClickBlocking;
             if (ClearInputLocks.modeWindow != null)
             {
                 visible = true;
@@ -78,6 +79,7 @@ namespace ClickThroughFix
         bool focusFollowsClick = false;
         bool oldFocusFollowsMouse = false;
         bool oldFocusFollowsClick = false;
+        bool universalClickBlocking = false;
         void PopUpWindow(int id)
         {
             GUILayout.BeginVertical();
@@ -103,16 +105,21 @@ namespace ClickThroughFix
                 oldFocusFollowsClick = true;
                 focusFollowsMouse = oldFocusFollowsMouse = false;
             }
+            GUILayout.Space(10);
+            universalClickBlocking = GUILayout.Toggle(universalClickBlocking,
+                "Universal IMGUI click-through blocking (covers mods that don't use CTB)");
             if (!focusFollowsClick && !focusFollowsMouse)
                 GUI.enabled = false;
             GUILayout.BeginHorizontal();
             if (GUILayout.Button("Save as global default for all new saves"))
             {
-                SaveGlobalDefault(focusFollowsClick);
+                SaveGlobalDefault(focusFollowsClick, universalClickBlocking);
             }
             if (GUILayout.Button("Accept"))
             {
                 HighLogic.CurrentGame.Parameters.CustomParams<CTB>().focusFollowsclick = focusFollowsClick;
+                HighLogic.CurrentGame.Parameters.CustomParams<CTB>().universalClickBlocking = universalClickBlocking;
+                ClearInputLocks.universalClickBlocking = universalClickBlocking;
                 HighLogic.CurrentGame.Parameters.CustomParams<CTB>().showPopup = false;
                 CreatePopUpFlagFile();
                 ClearInputLocks.ClearInputLocksToggle();
@@ -140,10 +147,11 @@ namespace ClickThroughFix
                 return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/../Global.cfg";
             }
         }
-        static internal void SaveGlobalDefault(bool focusFollowsClick)
+        static internal void SaveGlobalDefault(bool focusFollowsClick, bool universalClickBlocking)
         {
             ConfigNode node = new ConfigNode();
             node.AddValue("focusFollowsClick", focusFollowsClick);
+            node.AddValue("universalClickBlocking", universalClickBlocking);
             node.Save(GlobalDefaultFile);
         }
 
@@ -161,6 +169,20 @@ namespace ClickThroughFix
                 }
                 else
                     return HighLogic.CurrentGame.Parameters.CustomParams<CTB>().focusFollowsclick;
+            }
+            return false;
+        }
+
+        static internal bool GetGlobalDefaultUniversal(ref bool b)
+        {
+            if (System.IO.File.Exists(GlobalDefaultFile))
+            {
+                if (HighLogic.CurrentGame == null || HighLogic.CurrentGame.Parameters.CustomParams<CTB>().global)
+                {
+                    ConfigNode node = ConfigNode.Load(GlobalDefaultFile);
+                    if (node.TryGetValue("universalClickBlocking", ref b))
+                        return true;
+                }
             }
             return false;
         }

--- a/ClickThroughBlocker/RegisterToolbar.cs
+++ b/ClickThroughBlocker/RegisterToolbar.cs
@@ -19,7 +19,9 @@ namespace ClickThroughFix
         void OnGameSettingsWritten()
         {
             if (HighLogic.CurrentGame != null && HighLogic.CurrentGame.Parameters.CustomParams<CTB>().global)
-                OneTimePopup.SaveGlobalDefault (HighLogic.CurrentGame.Parameters.CustomParams<CTB>().focusFollowsclick);
+                OneTimePopup.SaveGlobalDefault(
+                    HighLogic.CurrentGame.Parameters.CustomParams<CTB>().focusFollowsclick,
+                    HighLogic.CurrentGame.Parameters.CustomParams<CTB>().universalClickBlocking);
         }
 
         void OnGameNewStart()
@@ -31,6 +33,9 @@ namespace ClickThroughFix
                 HighLogic.CurrentGame.Parameters.CustomParams<CTB>().showPopup = false;
                 OneTimePopup.CreatePopUpFlagFile();
             }
+            bool u = false;
+            if (OneTimePopup.GetGlobalDefaultUniversal(ref u))
+                HighLogic.CurrentGame.Parameters.CustomParams<CTB>().universalClickBlocking = u;
         }
         void OnGameStateCreated(Game g)
         {
@@ -41,6 +46,9 @@ namespace ClickThroughFix
                 g.Parameters.CustomParams<CTB>().showPopup = false;
                 OneTimePopup.CreatePopUpFlagFile();
             }
+            bool u = false;
+            if (OneTimePopup.GetGlobalDefaultUniversal(ref u))
+                g.Parameters.CustomParams<CTB>().universalClickBlocking = u;
         }
     }
 }

--- a/ClickThroughBlocker/Settings.cs
+++ b/ClickThroughBlocker/Settings.cs
@@ -34,6 +34,10 @@ namespace ClickThroughFix
             toolTip = "Click on a window to move the  focus to it")]
         public bool focusFollowsclick = false;
 
+        [GameParameters.CustomParameterUI("Universal IMGUI click-through blocking",
+            toolTip = "Block clicks / mouse wheel / editor part-pick from passing through\nANY IMGUI mod window onto PAW, the uGUI EventSystem, or KSP's\neditor — even mods that haven't opted in via ClickThruBlocker.GUILayoutWindow.")]
+        public bool universalClickBlocking = false;
+
 
         [GameParameters.CustomParameterUI("Focus change is global",
          toolTip = "This will make it a global setting for all games")]


### PR DESCRIPTION
CTB currently only protects windows that mods explicitly route through `ClickThruBlocker.GUILayoutWindow(...)`. The big mods that haven't (MechJeb, KAC, the various IMGUI panels in RP-1, etc.) still leak clicks through to:

- **Unity uGUI** — PAW controls, the toolbar, KSC facility menus, R&D node buttons, etc. left-click through any IMGUI window sitting over them.
- **The stock Part Action Window** — right-click on a mod window over a part also pops the PAW.
- **Editor part-pick** — single and double-click in the editor still picks up a part hidden behind the mod window, because the editor polls `Input.GetMouseButton` and isn't reachable from a uGUI raycaster patch.
- **Mouse wheel** — scrolling onto a PAW slider behind a mod window still moves the slider.

This PR adds an optional Harmony-postfix on every `GUI.Window`/`GUILayout.Window` overload that records the returned rect, transformed through `GUI.matrix` so it's in screen-pixel coords regardless of how the mod draws. `ClickThruBlocker.MouseOverAnyWindow()` becomes a one-line wrapper around the new universal tracker (`IMGUIWindowTracker`), so mods using the existing API automatically inherit the broader coverage.

<img width="1326" height="382" alt="image" src="https://github.com/user-attachments/assets/4125e1be-dbb0-4d16-9c81-3901f025a1c2" />
<img width="584" height="400" alt="image" src="https://github.com/user-attachments/assets/ddbaf476-fa2c-46d2-9f28-8fb2b8124b07" />

Three suppression paths key off the single tracker check:

1. `GraphicRaycaster.Raycast` prefix returns `false` → no uGUI hits → blocks left-clicks to PAW controls and any other uGUI element behind the mod window.
2. `UIPartActionController.MouseClickCoroutine` prefix bails → blocks right-click-through-to-part popping the PAW.
3. A small `KSPAddon` (`CTBHarmonyLoader`) runs each `Update()` and, if `MouseOverAnyWindow()`, sets `EditorLogic.Lock(true,true,true,…)` in editor scenes and `InputLockManager.SetControlLock(ControlTypes.ALLBUTCAMERAS, …)` in flight/map scenes. Released when the cursor leaves. This blocks the polled paths (editor part-pick, staging, flight controls, mouse-wheel-onto-PAW) for IMGUI windows that don't otherwise self-lock.

The rect-transform via `GUI.matrix` is key: KAC respects KSP's `UI_SCALE` so its rect lives inside that matrix, while MechJeb overrides `GUI.matrix` to identity. By applying whatever matrix is in effect at the moment `GUILayout.Window` returns, the stored rect is always in actual screen pixels and `Contains(Input.mousePosition)` works for both kinds of mods.

0Harmony is added as a build-time reference (already shipped by the standard `000_Harmony` install everyone has, so no new runtime dependency for users).

Tested in RP-1 + KAC + MechJeb: KAC over PAW blocks both left/right clicks, double-click-to-move-part, and mouse-wheel-onto-PAW; MechJeb the same. Stock KSP UI (toolbar, app launcher, bottom-edge buttons) remains fully clickable.